### PR TITLE
Deprecate misspelled handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export default defineConfig({
     }),
     /** Attention! The legacy plugin must before loaded than dynamic-publicpath plugin */
     useDynamicPublicPath({
-      dynamicImportHanlder: 'window.__dynamic_handler__',
+      dynamicImportHandler: 'window.__dynamic_handler__',
       dynamicImportPreload: 'window.__dynamic_preload__'
     }),
   ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,14 @@
 export interface Options {
     /**
      * default: window.__dynamicImportHandler__
+     * @deprecated: This will be removed in future versions.
+     * as it is spelled incorrectly.
      */
     dynamicImportHanlder?: string,
+    /**
+     * default: window.__dynamicImportHandler__
+     */
+    dynamicImportHandler?: string,
     /**
      * default: window.__dynamicImportPreload__
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@ import path from 'path';
 import { parse as parseImports, ImportSpecifier } from 'es-module-lexer'
 import { normalizePath, Plugin } from 'vite';
 import { Options } from '../index';
+import { DEPRECATION_WARNING } from './text-utils';
 
 export function useDynamicPublicPath(options?: Options): Plugin {
     const _defaultOptions : Options = {
-        dynamicImportHanlder: 'window.__dynamicImportHandler__',
+        dynamicImportHandler: 'window.__dynamicImportHandler__',
         dynamicImportPreload: 'window.__dynamicImportPreload__',
         assetsBase: 'assets',
     }
@@ -14,9 +15,15 @@ export function useDynamicPublicPath(options?: Options): Plugin {
 
     const {
         dynamicImportHanlder,
+        dynamicImportHandler,
         dynamicImportPreload,
         assetsBase,
     } = options;
+
+    const dynamicImportHandlerFinal = dynamicImportHandler || dynamicImportHanlder;
+    if (!!dynamicImportHanlder) {
+        console.warn(DEPRECATION_WARNING);
+    }
     
     return {
         name: 'vite-plugin-dynamic-publicpath',
@@ -25,12 +32,12 @@ export function useDynamicPublicPath(options?: Options): Plugin {
         renderDynamicImport({ format }) {
             if (format === 'es') {
                 return {
-                    left: `import("__PUBLIC_PATH_MARKER__" + (${dynamicImportHanlder} || function(importer) { return importer; })(`,
+                    left: `import("__PUBLIC_PATH_MARKER__" + (${dynamicImportHandlerFinal} || function(importer) { return importer; })(`,
                     right: ') + "__PUBLIC_PATH_MARKER__" )'
                 };
             } else if (format === 'system') {
                 return {
-                    left: `module.import((${dynamicImportHanlder} || function(importer) { return importer; })(`,
+                    left: `module.import((${dynamicImportHandlerFinal} || function(importer) { return importer; })(`,
                     right: '))'
                 };
             }

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -1,0 +1,11 @@
+const BOLD="\033[1m";
+const GREEN = "\033[32m";
+const RED = "\033[31m";
+const YELLOW = "\033[33m";
+const RESET = "\033[0m";
+
+export const DEPRECATION_WARNING = `
+ ⚠️  ${BOLD}${YELLOW}DEPRECATION WARNING${RESET} ⚠️ 
+    Please use \`${BOLD}dynamicImport${GREEN}Handler${RESET}\` instead of \`${BOLD}dynamicImport${RED}Hanlder${RESET}\`
+    Future versions of vite-plugin-dynamic-public-path will remove \`${BOLD}dynamicImport${RED}Hanlder${RESET}\`
+`;


### PR DESCRIPTION
This PR seeks to simply fix a typo! It prefers the proper spelling, but gracefully falls back to the existing handler. It warns of the usage of the old.